### PR TITLE
feature: disable title toggle is now functional

### DIFF
--- a/assets/css/admin-style.css
+++ b/assets/css/admin-style.css
@@ -21,3 +21,26 @@
     order: 1;
     width: auto;
 }
+
+.editor-styles-wrapper--title-disabled {
+    padding-top: 0;
+}
+
+.editor-styles-wrapper--title-disabled .editor-post-title {
+    padding-top: 44px;
+    height: 135px;
+    background: #fff;
+    height: 135px;
+    border-bottom: 1px #e2e4e7 solid;
+}
+
+.editor-styles-wrapper--title-disabled .editor-post-title__block .editor-post-title__input {
+    text-align: left;
+    font-size: 36px;
+    font-weight: 400;
+    color: #999;
+}
+
+.editor-styles-wrapper--title-disabled .wp-block.editor-post-title__block.is-selected .editor-post-title__input {
+    color: #191e23;
+}

--- a/assets/js/admin-script.js
+++ b/assets/js/admin-script.js
@@ -1,0 +1,5 @@
+jQuery(function($) {
+    $('[name="acf[field_smvmt2020_appearance_disable_title]"]').change(function () {
+        $('.editor-styles-wrapper').toggleClass('editor-styles-wrapper--title-disabled');
+    });
+});

--- a/functions.php
+++ b/functions.php
@@ -12,9 +12,10 @@ function enqueue_parent_styles() {
 /**
  * Enqeue custom admin styles
  */
-add_action( 'admin_enqueue_scripts', 'enqueue_admin_styles' );
+add_action( 'admin_enqueue_scripts', 'enqueue_admin_assets' );
 
-function enqueue_admin_styles() {
+function enqueue_admin_assets() {
+    wp_enqueue_script( 'smvmt2020-admin-script', get_stylesheet_directory_uri().'/assets/js/admin-script.js', ['jquery'] );
    wp_enqueue_style( 'smvmt2020-admin-style', get_stylesheet_directory_uri().'/assets/css/admin-style.css' );
 }
 

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Overrides the default template for displaying content
+ *
+ * Used for both singular and index.
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ *
+ * @package WordPress
+ * @subpackage Twenty_Twenty
+ * @since 1.0.0
+ */
+
+?>
+
+<article <?php post_class(); ?> id="post-<?php the_ID(); ?>">
+
+    <?php
+    
+    // Only include featured image/entry header if 
+    // title is not disabled for this content
+
+    if ( !get_field('disable_title') ) {
+
+        get_template_part( 'template-parts/entry-header' );
+
+        if ( ! is_search() ) {
+            get_template_part( 'template-parts/featured-image' );
+        }
+
+    }
+
+	?>
+
+	<div class="post-inner <?php echo is_page_template( 'templates/template-full-width.php' ) ? '' : 'thin'; ?> ">
+
+		<div class="entry-content">
+
+			<?php
+			if ( is_search() || ! is_singular() && 'summary' === get_theme_mod( 'blog_content', 'full' ) ) {
+				the_excerpt();
+			} else {
+				the_content( __( 'Continue reading', 'twentytwenty' ) );
+			}
+			?>
+
+		</div><!-- .entry-content -->
+
+	</div><!-- .post-inner -->
+
+	<div class="section-inner">
+		<?php
+		wp_link_pages(
+			array(
+				'before'      => '<nav class="post-nav-links bg-light-background" aria-label="' . esc_attr__( 'Page', 'twentytwenty' ) . '"><span class="label">' . __( 'Pages:', 'twentytwenty' ) . '</span>',
+				'after'       => '</nav>',
+				'link_before' => '<span class="page-number">',
+				'link_after'  => '</span>',
+			)
+		);
+
+		edit_post_link();
+
+		// Single bottom post meta.
+		twentytwenty_the_post_meta( get_the_ID(), 'single-bottom' );
+
+		if ( is_single() ) {
+
+			get_template_part( 'template-parts/entry-author-bio' );
+
+		}
+		?>
+
+	</div><!-- .section-inner -->
+
+	<?php
+
+	if ( is_single() ) {
+
+		get_template_part( 'template-parts/navigation' );
+
+	}
+
+	/**
+	 *  Output comments wrapper if it's a post, or if comments are open,
+	 * or if there's a comment number – and check for password.
+	 * */
+	if ( ( is_single() || is_page() ) && ( comments_open() || get_comments_number() ) && ! post_password_required() ) {
+		?>
+
+		<div class="comments-wrapper section-inner">
+
+			<?php comments_template(); ?>
+
+		</div><!-- .comments-wrapper -->
+
+		<?php
+	}
+	?>
+
+</article><!-- .post -->


### PR DESCRIPTION
## Description
This PR introduces functionality for the 'Disable Title' toggle on posts. Now, when box is checked, the page does not include the post header section or featured image section. Additionally, when the box is checked, the post title area of the editor is restyled to appear more like a document title, as opposed to being a part of the page.

## Affects
This solution impacts content markup (template-parts/content.php) and introduces additional admin styles and scripts (functions.php and assets folder).

## Visuals
<img width="862" alt="Screen Shot 2020-05-07 at 8 00 59 AM" src="https://user-images.githubusercontent.com/5186078/81292100-0171eb00-9039-11ea-86d4-5afc6d491aa1.png">

<img width="1042" alt="Screen Shot 2020-05-07 at 8 01 20 AM" src="https://user-images.githubusercontent.com/5186078/81292110-059e0880-9039-11ea-8d81-e57bba7950fd.png">
