### PR TITLE
feature: add disable top spacing functionality

### DIFF
--- a/assets/css/admin-style.css
+++ b/assets/css/admin-style.css
@@ -32,6 +32,7 @@
     background: #fff;
     height: 135px;
     border-bottom: 1px #e2e4e7 solid;
+    margin-bottom: 6rem;
 }
 
 .editor-styles-wrapper--title-disabled .editor-post-title__block .editor-post-title__input {
@@ -43,4 +44,13 @@
 
 .editor-styles-wrapper--title-disabled .wp-block.editor-post-title__block.is-selected .editor-post-title__input {
     color: #191e23;
+}
+
+.editor-styles-wrapper--top-spacing-disabled .editor-post-title {
+    margin-bottom: 0!important;
+}
+
+.editor-styles-wrapper--top-spacing-disabled .block-editor-block-list__block:first-of-type,
+.editor-styles-wrapper--top-spacing-disabled .block-editor-block-list__block:first-of-type .wp-block-embed {
+    margin-top: 0!important;
 }

--- a/assets/js/admin-script.js
+++ b/assets/js/admin-script.js
@@ -1,5 +1,20 @@
 jQuery(function($) {
+
+    const interval = setInterval( function() {
+        if ( $('.editor-styles-wrapper').length !== 0 ) {
+            setupWrapperClass();
+        }
+    }, 50);
+
+    function setupWrapperClass () {
+        clearInterval(interval);
+        if ( acf.getField('field_smvmt2020_appearance_disable_title').val() === 1 ) {
+            $('.editor-styles-wrapper').toggleClass('editor-styles-wrapper--title-disabled');
+        }
+    }
+
     $('[name="acf[field_smvmt2020_appearance_disable_title]"]').change(function () {
         $('.editor-styles-wrapper').toggleClass('editor-styles-wrapper--title-disabled');
     });
+    
 });

--- a/assets/js/admin-script.js
+++ b/assets/js/admin-script.js
@@ -11,10 +11,17 @@ jQuery(function($) {
         if ( acf.getField('field_smvmt2020_appearance_disable_title').val() === 1 ) {
             $('.editor-styles-wrapper').toggleClass('editor-styles-wrapper--title-disabled');
         }
+        if ( acf.getField('field_smvmt2020_appearance_disable_top_spacing').val() === 1 ) {
+            $('.editor-styles-wrapper').toggleClass('editor-styles-wrapper--top-spacing-disabled');
+        }
     }
 
     $('[name="acf[field_smvmt2020_appearance_disable_title]"]').change(function () {
         $('.editor-styles-wrapper').toggleClass('editor-styles-wrapper--title-disabled');
     });
-    
+
+    $('[name="acf[field_smvmt2020_appearance_disable_top_spacing]"]').change(function () {
+        $('.editor-styles-wrapper').toggleClass('editor-styles-wrapper--top-spacing-disabled');
+    });
+
 });

--- a/assets/js/admin-script.js
+++ b/assets/js/admin-script.js
@@ -16,11 +16,19 @@ jQuery(function($) {
         }
     }
 
-    $('[name="acf[field_smvmt2020_appearance_disable_title]"]').change(function () {
+    $('[name="acf[field_smvmt2020_appearance_disable_title]"]').change(function (evt) {
         $('.editor-styles-wrapper').toggleClass('editor-styles-wrapper--title-disabled');
     });
 
+    acf.addAction('show_field/key=field_smvmt2020_appearance_disable_top_spacing', function () {
+        if ( acf.getField('field_smvmt2020_appearance_disable_top_spacing').val() === 1 ) {
+            console.log('top spacing disabled');
+            $('.editor-styles-wrapper').addClass('editor-styles-wrapper--top-spacing-disabled');
+        }
+    }); 
+
     $('[name="acf[field_smvmt2020_appearance_disable_top_spacing]"]').change(function () {
+        console.log('top spacing', acf.getField('field_smvmt2020_appearance_disable_top_spacing').val());
         $('.editor-styles-wrapper').toggleClass('editor-styles-wrapper--top-spacing-disabled');
     });
 

--- a/functions.php
+++ b/functions.php
@@ -10,13 +10,26 @@ function enqueue_parent_styles() {
 }
 
 /**
- * Enqeue custom admin styles
+ * Enqeue custom admin assets
  */
 add_action( 'admin_enqueue_scripts', 'enqueue_admin_assets' );
 
 function enqueue_admin_assets() {
     wp_enqueue_script( 'smvmt2020-admin-script', get_stylesheet_directory_uri().'/assets/js/admin-script.js', ['jquery'] );
    wp_enqueue_style( 'smvmt2020-admin-style', get_stylesheet_directory_uri().'/assets/css/admin-style.css' );
+}
+
+/**
+ * Add Body class if top spacing is disabled
+ */
+add_filter( 'body_class', 'smvmt2020_add_body_class' );
+
+function smvmt2020_add_body_class ( $classes ) {
+    if ( get_field('disable_title') && get_field('disable_top_spacing') ) {
+        return array_merge( $classes, ['smvmt2020--top-spacing-disabled'] );
+    } else {
+        return $classes;
+    }
 }
 
 /**

--- a/includes/fields/fields.php
+++ b/includes/fields/fields.php
@@ -54,7 +54,15 @@ acf_add_local_field_group([
             'type' => 'true_false',
             'instructions' => '',
             'required' => 0,
-            'conditional_logic' => 0,
+            'conditional_logic' => [
+				[
+					[
+						'field' => 'field_smvmt2020_appearance_disable_title',
+						'operator' => '==',
+						'value' => '1',
+                    ],
+                ],
+            ],
             'wrapper' => [
                 'width' => '',
                 'class' => 'smvmt2020-input smvmt2020-input--inline',

--- a/includes/fields/fields.php
+++ b/includes/fields/fields.php
@@ -10,9 +10,9 @@ acf_add_local_field_group([
     'title' => 'Appearance',
     'fields' => [
         [
-            'key' => 'field_smvmt2020_appearance_disable_title',
-            'label' => 'Disable Title',
-            'name' => 'disable_title',
+            'key' => 'field_smvmt2020_appearance_use_transparent_header',
+            'label' => 'Use Transparent Header',
+            'name' => 'use_transparent_header',
             'type' => 'true_false',
             'instructions' => '',
             'required' => 0,
@@ -29,9 +29,9 @@ acf_add_local_field_group([
             'ui_off_text' => '',
         ],
         [
-            'key' => 'field_smvmt2020_appearance_use_transparent_header',
-            'label' => 'Use Transparent Header',
-            'name' => 'use_transparent_header',
+            'key' => 'field_smvmt2020_appearance_disable_title',
+            'label' => 'Disable Title',
+            'name' => 'disable_title',
             'type' => 'true_false',
             'instructions' => '',
             'required' => 0,

--- a/style.css
+++ b/style.css
@@ -11,3 +11,17 @@
  Tags:         light, dark, two-columns, right-sidebar, responsive-layout, accessibility-ready
  Text Domain:  twentytwentychild
 */
+
+.smvmt2020--top-spacing-disabled .post-inner {
+    padding-top: 0;
+}
+
+.smvmt2020--top-spacing-disabled .page {
+    margin-top: 0px;
+}
+
+@media (min-width: 1220px) {
+    .smvmt2020--top-spacing-disabled .entry-content > *:first-child {
+        margin-top: 0;
+    }
+}

--- a/style.css
+++ b/style.css
@@ -12,6 +12,11 @@
  Text Domain:  twentytwentychild
 */
 
+/* 
+    Disableed Top Spacing styles
+    These styles are applied only on pages with top spacing disabled
+*/
+
 .smvmt2020--top-spacing-disabled .post-inner {
     padding-top: 0;
 }


### PR DESCRIPTION
## Description
This PR introduces the disable top spacing functionality, to support the existing 'Disable Top Spacing' toggle on pages. It uses acf Javascript actions to ensure that the editor is responsive to changes, and adds a filter in functions.php to add a body class when top spacing is disabled.

## Affects
This PR affects style.css, functions.php and the assets folder.

## Visuals
<img width="1054" alt="Screen Shot 2020-05-07 at 11 30 35 AM" src="https://user-images.githubusercontent.com/5186078/81314098-b5ce3a00-9056-11ea-8ef4-65f7681156e9.png">

<img width="1058" alt="Screen Shot 2020-05-07 at 11 33 11 AM" src="https://user-images.githubusercontent.com/5186078/81314108-b8c92a80-9056-11ea-8bb7-cd1f1272cd2d.png">
