### PR TITLE
feature: add use transparent header functionality

### DIFF
--- a/assets/css/admin-style.css
+++ b/assets/css/admin-style.css
@@ -22,6 +22,26 @@
     width: auto;
 }
 
+.smvmt2020-input--subfield {
+    background: #f3f4f5;
+    display: flex;
+    align-items: center;
+}
+
+.smvmt2020-input--subfield .acf-label {
+    margin: 0!important;
+    padding-left: 30px;
+}
+
+.smvmt2020-input--subfield .acf-label > label {
+    font-weight: 400!important;
+}
+
+.smvmt2020-input--subfield .acf-input {
+    width: auto;
+    padding-left: 30px;
+}
+
 .editor-styles-wrapper--title-disabled {
     padding-top: 0;
 }

--- a/functions.php
+++ b/functions.php
@@ -25,12 +25,44 @@ function enqueue_admin_assets() {
 add_filter( 'body_class', 'smvmt2020_add_body_class' );
 
 function smvmt2020_add_body_class ( $classes ) {
+
+    $append = [];
     if ( get_field('disable_title') && get_field('disable_top_spacing') ) {
-        return array_merge( $classes, ['smvmt2020--top-spacing-disabled'] );
-    } else {
-        return $classes;
+        array_push( $append, 'smvmt2020--top-spacing-disabled' );
     }
+
+    if ( get_field('use_transparent_header') ) {
+        array_push( $append, 'smvmt2020--transparent-header-enabled' );
+    }
+    
+    return array_merge( $classes, $append );
 }
+
+/**
+ * Add dynamic inline styling
+ */
+function smvmt2020_dynamic_css() {
+
+    if ( get_field('use_transparent_header') ) {
+        $color = get_field('header_font_color');
+        $dynamic_css = "
+            .site-title a,
+            .site-description,
+            .primary-menu > li > a,
+            .toggle-inner,
+            .toggle-text {
+                color: {$color}!important;
+            }
+            .header-footer-group .header-inner .toggle-wrapper::before {
+                background-color: {$color}!important;
+                opacity: 0.5;
+            }
+        ";
+        wp_add_inline_style( 'parent-style', $dynamic_css );
+    }
+
+}
+add_action( 'wp_enqueue_scripts', 'smvmt2020_dynamic_css' );
 
 /**
  * Setup Advanced Custom Fields

--- a/functions.php
+++ b/functions.php
@@ -48,9 +48,9 @@ function smvmt2020_dynamic_css() {
         $dynamic_css = "
             .site-title a,
             .site-description,
-            .primary-menu > li > a,
-            .toggle-inner,
-            .toggle-text {
+            body:not(.overlay-header) .primary-menu > li > a,
+            body:not(.overlay-header) .toggle-inner,
+            body:not(.overlay-header) .toggle-inner .toggle-text {
                 color: {$color}!important;
             }
             .header-footer-group .header-inner .toggle-wrapper::before {

--- a/includes/fields/fields.php
+++ b/includes/fields/fields.php
@@ -29,6 +29,29 @@ acf_add_local_field_group([
             'ui_off_text' => '',
         ],
         [
+			'key' => 'field_smvmt2020_appearance_header_font_color',
+			'label' => 'Header Font Color',
+			'name' => 'header_font_color',
+			'type' => 'color_picker',
+			'instructions' => '',
+			'required' => 0,
+			'conditional_logic' => [
+				[
+					[
+						'field' => 'field_smvmt2020_appearance_use_transparent_header',
+						'operator' => '==',
+						'value' => '1',
+                    ],
+                ],
+            ],
+			'wrapper' => [
+                'width' => '',
+                'class' => 'smvmt2020-input smvmt2020-input--subfield',
+                'id' => '',
+            ],
+			'default_value' => '#ffde16',
+        ],
+        [
             'key' => 'field_smvmt2020_appearance_disable_title',
             'label' => 'Disable Title',
             'name' => 'disable_title',

--- a/style.css
+++ b/style.css
@@ -30,3 +30,10 @@
         margin-top: 0;
     }
 }
+
+.smvmt2020--transparent-header-enabled #site-header {
+    position: absolute;
+    width: 100%;
+    background: none;
+    z-index: 99;
+}


### PR DESCRIPTION
## Description
This PR introduces functionality for the 'Use Transparent Header' toggle, and 'Header Font Color' colorpicker on pages.

## Affects
This PR impacts functions.php, the assets directory and fields.php.

## Visuals 
<img width="1175" alt="Screen Shot 2020-05-07 at 12 53 41 PM" src="https://user-images.githubusercontent.com/5186078/81322614-41999380-9062-11ea-995b-31ef75c72f5a.png">
