### PR TITLE
feature: add link highlighted link support

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -45,6 +45,7 @@ function smvmt2020_dynamic_css() {
 
     if ( get_field('use_transparent_header') ) {
         $color = get_field('header_font_color');
+        $text_color = smvmt2020_get_highlight_text_color( $color );
         $dynamic_css = "
             .site-title a,
             .site-description,
@@ -57,12 +58,37 @@ function smvmt2020_dynamic_css() {
                 background-color: {$color}!important;
                 opacity: 0.5;
             }
+            body:not(.overlay-header) .primary-menu > .smvmt2020-highlight {
+                background: {$color}!important;
+            }
+            body:not(.overlay-header) .primary-menu > .smvmt2020-highlight a {
+                color: {$text_color}!important;
+            }
         ";
         wp_add_inline_style( 'parent-style', $dynamic_css );
     }
 
 }
 add_action( 'wp_enqueue_scripts', 'smvmt2020_dynamic_css' );
+
+function smvmt2020_get_highlight_text_color ($bg){
+    $bg = trim($bg, '#');
+    $r = hexdec(substr($bg,0,2));
+    $g = hexdec(substr($bg,2,2));
+    $b = hexdec(substr($bg,4,2));
+
+    $squared_contrast = (
+        $r * $r * .299 +
+        $g * $g * .587 +
+        $b * $b * .114
+    );
+
+    if($squared_contrast > pow(130, 2)){
+        return 'rgb(51,52,46)';
+    }else{
+        return '#FFFFFF';
+    }
+}
 
 /**
  * Setup Advanced Custom Fields

--- a/style.css
+++ b/style.css
@@ -37,3 +37,13 @@
     background: none;
     z-index: 99;
 }
+
+body:not(.overlay-header) .primary-menu > .smvmt2020-highlight {
+    padding: 12px 18px;
+    background: #ffde16;
+    margin-top: -4px;
+}
+
+body:not(.overlay-header) .primary-menu > .smvmt2020-highlight a {
+    color: rgb(51,52,46);
+}


### PR DESCRIPTION
## Description
Resolves #4 
This PR introduces the `smvmt2020-highlight` class which can be applied to links in the primary menu to set them apart. It is modeled off the the Donate button found in the existing SquareSpace site.

This PR also sets up highlighted links to inherit the colors set for transparent headers. It then uses a basic algorithm to set the button's font color to either light or dark, dependent on the color of the button.

## Affects
This PR only impacts the style.css and the functions.php file.

## Visuals 
<img width="1049" alt="Screen Shot 2020-05-07 at 2 13 19 PM" src="https://user-images.githubusercontent.com/5186078/81329755-0355a180-906d-11ea-90ae-8d02061bbb34.png">

<img width="1126" alt="Screen Shot 2020-05-07 at 2 08 56 PM" src="https://user-images.githubusercontent.com/5186078/81329776-06509200-906d-11ea-8b15-a907cfca5476.png">
