### PR TITLE
fix: restyle header to match SquareSpace design

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -46,13 +46,26 @@ function smvmt2020_dynamic_css() {
     if ( get_field('use_transparent_header') ) {
         $color = get_field('header_font_color');
         $text_color = smvmt2020_get_highlight_text_color( $color );
+        $submenu_bg = $text_color === '#FFFFFF' ? $color : $text_color;
+        $submenu_border = $text_color === '#FFFFFF' ? smvmt2020_shift_color($color, 60) : $color;
+        $submenu_text = $text_color === '#FFFFFF' ? $text_color : $color;
         $dynamic_css = "
             .site-title a,
             .site-description,
-            body:not(.overlay-header) .primary-menu > li > a,
-            body:not(.overlay-header) .toggle-inner,
+            body:not(.overlay-header) .primary-menu li:not(.smvmt2020-highlight) a,
+            body:not(.overlay-header) .primary-menu li a,
+            body:not(.overlay-header) .toggle-inner .toggle-text {
+                text-transform: uppercase;
+                font-weight: 700;
+            }
+            .site-title a,
+            .site-description,
+            body:not(.overlay-header) .primary-menu > li:not(.smvmt2020-highlight) > a,
             body:not(.overlay-header) .toggle-inner .toggle-text {
                 color: {$color}!important;
+            }
+            body:not(.overlay-header) .sub-menu a {
+                color: {$submenu_text}!important;
             }
             .header-footer-group .header-inner .toggle-wrapper::before {
                 background-color: {$color}!important;
@@ -63,6 +76,35 @@ function smvmt2020_dynamic_css() {
             }
             body:not(.overlay-header) .primary-menu > .smvmt2020-highlight a {
                 color: {$text_color}!important;
+            }
+            body:not(.overlay-header) .primary-menu ul {
+                border-radius: 0px;
+                background-color: {$submenu_bg}!important;
+                color: {$submenu_text}!important;
+            }
+            body:not(.overlay-header) .primary-menu > li > ul {
+                border-top: 3px {$submenu_border} solid!important;
+            }
+            body:not(.overlay-header) .primary-menu > li > ul:after {
+                border-bottom-color: {$submenu_border}!important;
+            }
+            body:not(.overlay-header) .primary-menu > li > ul > li > ul {
+                border-right: 3px {$submenu_border} solid!important;
+            }
+            body:not(.overlay-header) .primary-menu > li > ul > li > ul:after {
+                border-left-color: {$submenu_border}!important;
+            }
+        ";
+        wp_add_inline_style( 'parent-style', $dynamic_css );
+    } else {
+        $dynamic_css = "
+            body:not(.overlay-header) .primary-menu ul {
+                border-radius: 0px;
+                background-color: rgb(51,52,46)!important;
+                color: #ffde16!important;
+            }
+            body:not(.overlay-header) .primary-menu > li > ul:after {
+                border-bottom-color: #ffde16!important;
             }
         ";
         wp_add_inline_style( 'parent-style', $dynamic_css );
@@ -88,6 +130,14 @@ function smvmt2020_get_highlight_text_color ($bg){
     }else{
         return '#FFFFFF';
     }
+}
+
+function smvmt2020_shift_color ($color, $shift){
+    $color = trim($color, '#');
+    $r = hexdec(substr($color,0,2)) + $shift;
+    $g = hexdec(substr($color,2,2)) + $shift;
+    $b = hexdec(substr($color,4,2)) + $shift;
+    return sprintf("#%02x%02x%02x", $r, $g, $b);
 }
 
 /**

--- a/functions.php
+++ b/functions.php
@@ -134,9 +134,9 @@ function smvmt2020_get_highlight_text_color ($bg){
 
 function smvmt2020_shift_color ($color, $shift){
     $color = trim($color, '#');
-    $r = hexdec(substr($color,0,2)) + $shift;
-    $g = hexdec(substr($color,2,2)) + $shift;
-    $b = hexdec(substr($color,4,2)) + $shift;
+    $r = hexdec(substr($color,0,2)) + $shift < 255 ? hexdec(substr($color,0,2)) + $shift : 255;
+    $g = hexdec(substr($color,2,2)) + $shift < 255 ? hexdec(substr($color,2,2)) + $shift : 255;
+    $b = hexdec(substr($color,4,2)) + $shift < 255 ? hexdec(substr($color,4,2)) + $shift : 255;
     return sprintf("#%02x%02x%02x", $r, $g, $b);
 }
 

--- a/style.css
+++ b/style.css
@@ -47,3 +47,65 @@ body:not(.overlay-header) .primary-menu > .smvmt2020-highlight {
 body:not(.overlay-header) .primary-menu > .smvmt2020-highlight a {
     color: rgb(51,52,46);
 }
+
+/*
+    Header Styles
+*/
+
+.site-title a,
+.site-description,
+body:not(.overlay-header) .primary-menu li:not(.smvmt2020-highlight) a,
+body:not(.overlay-header) .primary-menu li a,
+body:not(.overlay-header) .toggle-inner .toggle-text {
+    text-transform: uppercase;
+    color: #ffde16;
+    font-weight: 700;
+}
+
+.site-title a,
+.site-title a:hover,
+body:not(.overlay-header) .primary-menu li a,
+body:not(.overlay-header) .primary-menu li a:hover,
+body:not(.overlay-header) .primary-menu .current_page_ancestor {
+    text-decoration: none;
+}
+
+body:not(.overlay-header) .primary-menu .menu-item-has-children:first-child > a {
+    padding-right: 0!important;
+}
+
+.menu-item-has-children > .icon {
+    display: none;
+}
+
+.primary-menu ul {
+    top: calc(100% + 0.2rem);
+}
+
+body:not(.overlay-header) .primary-menu ul {
+    border-radius: 0px;
+    background-color: rgb(51,52,46);
+    color: #ffde16!important;
+}
+
+body:not(.overlay-header) .primary-menu > li > ul {
+    border-top: 3px #ffde16 solid;
+}
+
+body:not(.overlay-header) .primary-menu > li > ul:after {
+    border-bottom-color: #ffde16;
+}
+
+body:not(.overlay-header) .primary-menu > li > ul > li > ul {
+    border-right: 3px #ffde16 solid;
+}
+
+body:not(.overlay-header) .primary-menu > li > ul > li > ul:after {
+    border-left-color: #ffde16;
+}
+
+.primary-menu ul li.menu-item-has-children:hover > ul,
+.primary-menu ul li.menu-item-has-children:focus > ul,
+.primary-menu ul li.menu-item-has-children.focus > ul {
+    right: 100%;
+}


### PR DESCRIPTION
## Description
Resolves #1 
This PR restyles various header styles to more closely match the existing SquareSpace design.
It also introduces functionality to dynamically set certain colors in the header on pages that use transparent header (specifically borders). 

## Affects
The PR touches style.css and functions.php.

## Visuals
<img width="1792" alt="Screen Shot 2020-05-07 at 4 19 26 PM" src="https://user-images.githubusercontent.com/5186078/81341050-e6c26500-907e-11ea-993e-256762c2da05.png">

<img width="1792" alt="Screen Shot 2020-05-07 at 4 18 31 PM" src="https://user-images.githubusercontent.com/5186078/81341059-ea55ec00-907e-11ea-9e33-0f6f938f96df.png">
